### PR TITLE
resume function

### DIFF
--- a/blocksync.py
+++ b/blocksync.py
@@ -335,9 +335,6 @@ def sync(workerid, srcdev, dsthost, dstdev, options):
         if pause_ms:
             time.sleep(pause_ms)
 
-        if not interactive:
-            continue
-
         t1 = float(time.time())
         if (t1 - t_last) >= interval:
             done_blocks = same_blocks + diff_blocks
@@ -347,7 +344,7 @@ def sync(workerid, srcdev, dsthost, dstdev, options):
             last_blocks = done_blocks
             t_last = t1
 
-        if (same_blocks + diff_blocks) == size_blocks:
+        if (same_blocks + diff_blocks) >= size_blocks:
             break
 
     rate = size_blocks * blocksize / (1024.0 * 1024) / (time.time() - t0)


### PR DESCRIPTION
this is a really quick and dirty resume function by writing current filepos of every worker to file
needed this because i wanted to sync really big files and when ssh disconnected the sync process began from the first block

i use this in a bash script like this:

until python /opt/remotebackup/blocksync.py [ ... ]
do
  sleep 30
done
rm syncpos*$(basename $image)*

i hope this helps and someone can rework this in a better way